### PR TITLE
Changing moment dependency to suggestion

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,8 +7,8 @@
     "calendar",
     "date"
   ],
-  "require": {
-      "webmodules/moment" : ">=2.10.4"
+  "suggest": {
+      "moment/moment": "Allows custom formatting of Pikaday dates"
   },
   "main": [
     "./pikaday.js",


### PR DESCRIPTION
"No dependencies" in the description was somewhat contradictory with the dependency on moment, so I've changed it from a requirement to a suggestion.
I've also changed it to suggest moment/moment instead of webmodules/moment - the former is up to date and much more commonly used on packagist.
